### PR TITLE
Speedup and cleaner changelog

### DIFF
--- a/netbox_ipscanner.py
+++ b/netbox_ipscanner.py
@@ -43,10 +43,15 @@ class IpScan(Script):
             scan.run()
             self.log_info(f'Scan of {subnet} done.')
 
+            # extract address info from Netbox
+            netbox_addresses = dict()
+            for ip in nb.ipam.ip_addresses.filter(parent=str(subnet)):
+                netbox_addresses[str(ip)] = ip
+
             # Routine to mark as DEPRECATED each Netbox entry that does not respond to ping
             for address in IPv4network.hosts(): # for each address of the prefix x.x.x.x/yy...
 		        #self.log_debug(f'checking {address}...')
-                netbox_address = nb.ipam.ip_addresses.get(address=address) # extract address info from Netbox
+                netbox_address = netbox_addresses.get(address)
                 if netbox_address != None: # if the ip exists in netbox // if none exists, leave it to discover
                     if str(netbox_address).rpartition('/')[0] in scan.list_of_hosts_found:  # if he is in the list of "alive"
                         pass # do nothing: It exists in NB and is in the pinged list: ok continue, you will see it later when you cycle the ip addresses that have responded whether to update something
@@ -62,7 +67,7 @@ class IpScan(Script):
                 self.log_success(f'IPs found: {scan.list_of_hosts_found}')
             for address1 in scan.list_of_hosts_found: # for each ip in the ping list...
                 ip_mask=str(address1)+mask
-                current_in_netbox = nb.ipam.ip_addresses.get(address=ip_mask) # extract current data in Netbox related to ip
+                current_in_netbox = netbox_addresses.get(ip_mask)
                 #self.log_debug(f'pinged ip: {address1} mask: {mask} --> {ip_mask} // extracted ip from netbox: {current_in_netbox}')
                 if current_in_netbox != None: # the pinged address is already present in the Netbox, mark it as Active and check the name if it has changed
                     if current_in_netbox.status.value != "active":

--- a/netbox_ipscanner.py
+++ b/netbox_ipscanner.py
@@ -65,7 +65,8 @@ class IpScan(Script):
                 current_in_netbox = nb.ipam.ip_addresses.get(address=ip_mask) # extract current data in Netbox related to ip
                 #self.log_debug(f'pinged ip: {address1} mask: {mask} --> {ip_mask} // extracted ip from netbox: {current_in_netbox}')
                 if current_in_netbox != None: # the pinged address is already present in the Netbox, mark it as Active and check the name if it has changed
-                    nb.ipam.ip_addresses.update([{'id':current_in_netbox.id, 'status':'active'},])
+                    if current_in_netbox.status.value != "active":
+                        nb.ipam.ip_addresses.update([{'id':current_in_netbox.id, 'status':'active'},])
                     name = reverse_lookup(address1) # name resolution from DNS
                     if current_in_netbox.dns_name == name: # the names in Netbox and DNS match, do nothing
                         pass

--- a/netbox_ipscanner.py
+++ b/netbox_ipscanner.py
@@ -68,7 +68,7 @@ class IpScan(Script):
                     if current_in_netbox.status.value != "active":
                         nb.ipam.ip_addresses.update([{'id':current_in_netbox.id, 'status':'active'},])
                     name = reverse_lookup(address1) # name resolution from DNS
-                    if current_in_netbox.dns_name == name: # the names in Netbox and DNS match, do nothing
+                    if current_in_netbox.dns_name.lower() == name.lower(): # the names in Netbox and DNS match, do nothing
                         pass
                     else: # the names in Netbox and in DNS *DO NOT* match --> update Netbox with DNS name
                         self.log_success(f'Name for {address1} updated to {name}')


### PR DESCRIPTION
Hello,
I cleaned up the NetBox Change Log on the Home dashboard:
- update to active will not be called when status is already "active"
- uppercase characters in DNS names are saved as lowercase in NetBox. This created empty changelogs for uppercase hostnames

I also added some speed (in my case from 59 minutes down to 14 minutes) by fetching all used IPs from the subnet at once and reusing it for the second loop.